### PR TITLE
Fix datetime issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+jdk: openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.brackit</groupId>
   <artifactId>brackit</artifactId>
-  <version>0.1.2</version>
+  <version>0.1.3-SNAPSHOT</version>
   <name>Brackit Engine</name>
   <url>http://brackit.org</url>
   <properties>

--- a/src/main/java/org/brackit/xquery/atomic/AbstractTimeInstant.java
+++ b/src/main/java/org/brackit/xquery/atomic/AbstractTimeInstant.java
@@ -27,7 +27,7 @@
  */
 package org.brackit.xquery.atomic;
 
-import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryException;
@@ -52,7 +52,7 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements
 	public static DTD LOCAL_TIMEZONE;
 
 	static {
-		int offset = Calendar.getInstance().getTimeZone().getRawOffset();
+		int offset = TimeZone.getDefault().getOffset(System.currentTimeMillis());
 		int hours = fQuotient(offset, 3600000);
 		int remainder = modulo(offset, 3600000);
 		int minutes = fQuotient(remainder, 60000);
@@ -268,11 +268,11 @@ public abstract class AbstractTimeInstant extends AbstractAtomic implements
 		boolean negative = false;
 		AbstractTimeInstant a = this;
 		
-		if (a.getTimezone() == null) {
+		if (a.getTimezone() != null) {
 			a = a.canonicalize();
 		}
-		if (b.getTimezone() == null) {
-			b.canonicalize();
+		if (b.getTimezone() != null) {
+			b = b.canonicalize();
 		}
 		
 		if (a.cmp(b) <= 0) {

--- a/src/main/java/org/brackit/xquery/atomic/DTD.java
+++ b/src/main/java/org/brackit/xquery/atomic/DTD.java
@@ -27,6 +27,8 @@
  */
 package org.brackit.xquery.atomic;
 
+import java.math.BigDecimal;
+
 import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryException;
 import org.brackit.xquery.util.Whitespace;
@@ -407,17 +409,17 @@ public class DTD extends AbstractDuration {
 				(byte) newMinutes, (int) newMicros);
 	}
 
-	public Dbl divide(DTD dur) throws QueryException {
-		long a = ((((((getDays() * 24l) + getHours()) * 59l) + getMinutes()) * 59l) * 1000000)
+	public Numeric divide(DTD dur) throws QueryException {
+		long a = ((((((getDays() * 24l) + getHours()) * 60l) + getMinutes()) * 60l) * 1000000)
 				+ getMicros();
-		long b = ((((((dur.getDays() * 24l) + dur.getHours()) * 59l) + dur
-				.getMinutes()) * 59l) * 1000000) + dur.getMicros();
+		long b = ((((((dur.getDays() * 24l) + dur.getHours()) * 60l) + dur
+				.getMinutes()) * 60l) * 1000000) + dur.getMicros();
 
 		if (b == 0) {
 			throw new QueryException(ErrorCode.ERR_DIVISION_BY_ZERO);
 		}
 
-		return new Dbl(a / b);
+		return new Dec(new BigDecimal(a)).div(new Dec(new BigDecimal(b)));
 	}
 
 	private DTD addInternal(boolean n2, short d2, byte h2, byte m2, int mic2)

--- a/src/main/java/org/brackit/xquery/atomic/DateTime.java
+++ b/src/main/java/org/brackit/xquery/atomic/DateTime.java
@@ -28,6 +28,7 @@
 package org.brackit.xquery.atomic;
 
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryException;
@@ -271,7 +272,9 @@ public class DateTime extends AbstractTimeInstant {
 	}
 
 	public DateTime(DTD timezone) {
-		Calendar cal = Calendar.getInstance();
+		int utcDiff = timezone.getHours() * 60 + (timezone.isNegative() ? -1 : 1) * timezone.getMinutes();
+		Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		cal.add(Calendar.MINUTE, utcDiff);
 		this.year = (short) cal.get(Calendar.YEAR);
 		this.month = (byte) (cal.get(Calendar.MONTH) + 1);
 		this.day = (byte) (cal.get(Calendar.DAY_OF_MONTH));

--- a/src/main/java/org/brackit/xquery/atomic/YMD.java
+++ b/src/main/java/org/brackit/xquery/atomic/YMD.java
@@ -27,6 +27,8 @@
  */
 package org.brackit.xquery.atomic;
 
+import java.math.BigDecimal;
+
 import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryException;
 import org.brackit.xquery.util.Whitespace;
@@ -262,7 +264,7 @@ public class YMD extends AbstractDuration {
 		return new YMD(newNegative, (short) newYears, (byte) newMonths);
 	}
 
-	public Dbl divide(YMD dur) throws QueryException {
+	public Numeric divide(YMD dur) throws QueryException {
 		int a = getYears() * 12 + getMonths();
 		int b = dur.getYears() * 12 + dur.getMonths();
 
@@ -270,7 +272,7 @@ public class YMD extends AbstractDuration {
 			throw new QueryException(ErrorCode.ERR_DIVISION_BY_ZERO);
 		}
 
-		return new Dbl(a / b);
+		return new Dec(new BigDecimal(a)).div(new Dec(new BigDecimal(b)));
 	}
 
 	private YMD addInternal(boolean n2, short y2, byte m2)

--- a/src/main/java/org/brackit/xquery/compiler/CompileChain.java
+++ b/src/main/java/org/brackit/xquery/compiler/CompileChain.java
@@ -42,6 +42,7 @@ import org.brackit.xquery.compiler.translator.TopDownTranslator;
 import org.brackit.xquery.compiler.translator.Translator;
 import org.brackit.xquery.function.bit.BitFun;
 import org.brackit.xquery.function.bit.Create;
+import org.brackit.xquery.function.bit.Now;
 import org.brackit.xquery.function.bit.Drop;
 import org.brackit.xquery.function.bit.Eval;
 import org.brackit.xquery.function.bit.Exists;
@@ -84,6 +85,7 @@ public class CompileChain {
 		Functions.predefine(BitFun.SOME_FUNC);
 		Functions.predefine(BitFun.EVERY_FUNC);
 		// Utility
+		Functions.predefine(new Now());
 		Functions.predefine(new Silent());
 		Functions.predefine(new Parse());
 		Functions.predefine(new Eval());

--- a/src/main/java/org/brackit/xquery/function/bit/Now.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Now.java
@@ -27,15 +27,13 @@
  */
 package org.brackit.xquery.function.bit;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.brackit.xquery.ErrorCode;
 import org.brackit.xquery.QueryContext;
 import org.brackit.xquery.QueryException;
 import org.brackit.xquery.atomic.AbstractTimeInstant;
-import org.brackit.xquery.atomic.DTD;
-import org.brackit.xquery.atomic.DateTime;
 import org.brackit.xquery.atomic.Int64;
 import org.brackit.xquery.atomic.QNm;
 import org.brackit.xquery.compiler.Bits;
@@ -73,21 +71,18 @@ public class Now extends AbstractFunction {
 			Sequence[] args) throws QueryException {
 		try {
 			AbstractTimeInstant dateTime = ctx.getDateTime().canonicalize();
-			int nanos = (int) ((dateTime.getMicros() % 1000000) * 1000);
+			int millis = (int) ((dateTime.getMicros() % 1000000) / 1000);
 			int seconds = (int) (dateTime.getMicros() / 1000000);
 			
-			OffsetDateTime dt = OffsetDateTime.of(
-				dateTime.getYear(),
-				dateTime.getMonth(),
-				dateTime.getDay(),
-				dateTime.getHours(),
-				dateTime.getMinutes(),
-				seconds,
-				nanos,
-				ZoneOffset.UTC
-			);
+			Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+			cal.set(Calendar.YEAR, dateTime.getYear());
+			cal.set(Calendar.MONTH, dateTime.getMonth() - 1);
+			cal.set(Calendar.HOUR_OF_DAY, dateTime.getHours());
+			cal.set(Calendar.MINUTE, dateTime.getMinutes());
+			cal.set(Calendar.SECOND, seconds);
+			cal.set(Calendar.MILLISECOND, millis);
 
-			long currentMillis = dt.toInstant().toEpochMilli();
+			long currentMillis = cal.getTimeInMillis();
 			return new Int64(currentMillis);
 		} catch (Exception e) {
 			throw new QueryException(e, ErrorCode.BIT_DYN_INT_ERROR);

--- a/src/main/java/org/brackit/xquery/function/bit/Now.java
+++ b/src/main/java/org/brackit/xquery/function/bit/Now.java
@@ -1,0 +1,96 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2011-2012, Brackit Project Team <info@brackit.org>  
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Brackit Project Team nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.brackit.xquery.function.bit;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.brackit.xquery.ErrorCode;
+import org.brackit.xquery.QueryContext;
+import org.brackit.xquery.QueryException;
+import org.brackit.xquery.atomic.AbstractTimeInstant;
+import org.brackit.xquery.atomic.DTD;
+import org.brackit.xquery.atomic.DateTime;
+import org.brackit.xquery.atomic.Int64;
+import org.brackit.xquery.atomic.QNm;
+import org.brackit.xquery.compiler.Bits;
+import org.brackit.xquery.function.AbstractFunction;
+import org.brackit.xquery.module.StaticContext;
+import org.brackit.xquery.util.annotation.FunctionAnnotation;
+import org.brackit.xquery.xdm.Sequence;
+import org.brackit.xquery.xdm.Signature;
+import org.brackit.xquery.xdm.type.AtomicType;
+import org.brackit.xquery.xdm.type.Cardinality;
+import org.brackit.xquery.xdm.type.SequenceType;
+
+/**
+ * 
+ * @author Sebastian Bächle
+ * 
+ */
+@FunctionAnnotation(description = "Returns the milliseconds since 1970/01/01.", parameters = "")
+public class Now extends AbstractFunction {
+
+	public static final QNm DEFAULT_NAME = new QNm(Bits.BIT_NSURI,
+			Bits.BIT_PREFIX, "now");
+
+	public Now() {
+		this(DEFAULT_NAME);
+	}
+
+	public Now(QNm name) {
+		super(name, new Signature(new SequenceType(AtomicType.INT,
+				Cardinality.One)), true);
+	}
+
+	@Override
+	public Sequence execute(StaticContext sctx, QueryContext ctx,
+			Sequence[] args) throws QueryException {
+		try {
+			AbstractTimeInstant dateTime = ctx.getDateTime().canonicalize();
+			int nanos = (int) ((dateTime.getMicros() % 1000000) * 1000);
+			int seconds = (int) (dateTime.getMicros() / 1000000);
+			
+			OffsetDateTime dt = OffsetDateTime.of(
+				dateTime.getYear(),
+				dateTime.getMonth(),
+				dateTime.getDay(),
+				dateTime.getHours(),
+				dateTime.getMinutes(),
+				seconds,
+				nanos,
+				ZoneOffset.UTC
+			);
+
+			long currentMillis = dt.toInstant().toEpochMilli();
+			return new Int64(currentMillis);
+		} catch (Exception e) {
+			throw new QueryException(e, ErrorCode.BIT_DYN_INT_ERROR);
+		}
+	}
+}

--- a/src/main/java/org/brackit/xquery/node/d2linked/D2Node.java
+++ b/src/main/java/org/brackit/xquery/node/d2linked/D2Node.java
@@ -82,10 +82,6 @@ public abstract class D2Node extends AbstractNode<D2Node> {
 	protected int localFragmentID = -1;
 
 	protected D2Node(ParentD2Node parent, int[] division) {
-		if ((this.parent != null) && (this.parent != parent)) {
-			throw new RuntimeException(String.format(
-					"Node is already connected to parent node %s.", parent));
-		}
 		this.parent = parent;
 		this.division = division;
 		this.localFragmentID = (parent == null) ? localFragmentID()

--- a/src/test/java/org/brackit/xquery/XQueryBaseTest.java
+++ b/src/test/java/org/brackit/xquery/XQueryBaseTest.java
@@ -38,6 +38,7 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.util.Random;
 
+import org.brackit.xquery.atomic.DTD;
 import org.brackit.xquery.node.SimpleStore;
 import org.brackit.xquery.node.parser.DocumentParser;
 import org.brackit.xquery.node.parser.SubtreeParser;
@@ -166,7 +167,12 @@ public class XQueryBaseTest {
 	}
 
 	protected QueryContext createContext() throws Exception {
-		return new QueryContext(store);
+		return new QueryContext(store) {
+			@Override
+			public DTD getImplicitTimezone() {
+				return new DTD(false, (short) 0, (byte) 2, (byte) 0, 0);
+			}
+		};
 	}
 
 	@Before

--- a/src/test/java/org/brackit/xquery/expr/CastTest.java
+++ b/src/test/java/org/brackit/xquery/expr/CastTest.java
@@ -257,22 +257,20 @@ public class CastTest extends XQueryBaseTest {
 	}
 
 
-	@Ignore
 	@Test
 	public void subtractDateTimes() throws QueryException {
 		Sequence res = new XQuery(
 				"xs:dateTime(\"2000-10-30T06:12:00\") -  xs:dateTime(\"1999-11-28T09:00:00\")")
 				.execute(ctx);
-		ResultChecker.dCheck(Bool.FALSE, res);
+		ResultChecker.dCheck(new DTD(false, (short) 336, (byte) 21, (byte) 12, 0), res);
 	}
 
-	@Ignore
 	@Test
 	public void subtractDateTimes2() throws QueryException {
 		Sequence res = new XQuery(
 				"xs:dateTime(\"2000-10-30T06:12:00\") -  xs:dateTime(\"1999-11-28T09:00:00Z\")")
 				.execute(ctx);
-		ResultChecker.dCheck(Bool.FALSE, res);
+		ResultChecker.dCheck(new DTD(false, (short) 336, (byte) 21, (byte) 12, 0), res);
 	}
 
 	@Test

--- a/src/test/java/org/brackit/xquery/function/fn/FnTest.java
+++ b/src/test/java/org/brackit/xquery/function/fn/FnTest.java
@@ -1519,7 +1519,7 @@ public class FnTest extends XQueryBaseTest {
 		Sequence result = new XQuery(
 				"fn:adjust-date-to-timezone(xs:date('2002-03-07-05:00'))")
 				.execute(ctx);
-		ResultChecker.dCheck(new Date("2002-03-07+01:00"), result);
+		ResultChecker.dCheck(new Date("2002-03-07+02:00"), result);
 	}
 
 	@Test


### PR DESCRIPTION
Resolved some issues with date/time related functionality like time zones and arithmetic. Also added a new function bit:now() -> xs:integer which returns a unix timestamp with the milliseconds from 1970/01/01

Using

`
let $now := bit:now()
`

is essentially more more efficient and concise alternative to the unix timestamp computation in pur XQuery:

`
let $now := xs:integer((current-dateTime() - xs:dateTime("1970-01-01T00:00:00-00:00")) div xs:dayTimeDuration('PT0.001S')).
`

See also [https://stackoverflow.com/questions/7482347/is-there-any-way-in-xquery-to-get-the-current-time-in-milliseconds-since-some-ep/7484211]

fixes #1 